### PR TITLE
Fix external link to structx

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,4 +212,4 @@ if foo {
 
 # See also
 
-- [structx](github.com/oooutlk/structx) offers similar features. I haven't checked how it works yet.
+- [structx](https://github.com/oooutlk/structx) offers similar features. I haven't checked how it works yet.


### PR DESCRIPTION
Github markdown rendered the original as a relative link.